### PR TITLE
fix(graphql-types): ensure short-description is defined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "camel-case": "^4.1.2",
                 "fp-ts": "^2.9.5",
-                "imgix-url-params": "^11.11.2",
+                "imgix-url-params": "^11.15.0",
                 "md5": "^2.3.0",
                 "node-fetch": "^2.6.1",
                 "param-case": "^3.0.4"
@@ -12001,9 +12001,9 @@
             }
         },
         "node_modules/imgix-url-params": {
-            "version": "11.13.0",
-            "resolved": "https://registry.npmjs.org/imgix-url-params/-/imgix-url-params-11.13.0.tgz",
-            "integrity": "sha512-GSt+jzX+h5CNuypBzHDDCdNT/PRdSwvK/zqYL47ATvEYuNO6lXwJL83Q97hiZVb3NO2HfP3sH7MVq6so9gEZWw=="
+            "version": "11.15.0",
+            "resolved": "https://registry.npmjs.org/imgix-url-params/-/imgix-url-params-11.15.0.tgz",
+            "integrity": "sha512-W8JprYztwdFTtNLTa/aj2PGh8CJNBaMKrTtgOYlo8OvJrRn3XELRTeZoLyob5C49qW9aFiIYIIqm8zWysRFu8g=="
         },
         "node_modules/immer": {
             "version": "9.0.18",
@@ -29303,9 +29303,9 @@
             "dev": true
         },
         "imgix-url-params": {
-            "version": "11.13.0",
-            "resolved": "https://registry.npmjs.org/imgix-url-params/-/imgix-url-params-11.13.0.tgz",
-            "integrity": "sha512-GSt+jzX+h5CNuypBzHDDCdNT/PRdSwvK/zqYL47ATvEYuNO6lXwJL83Q97hiZVb3NO2HfP3sH7MVq6so9gEZWw=="
+            "version": "11.15.0",
+            "resolved": "https://registry.npmjs.org/imgix-url-params/-/imgix-url-params-11.15.0.tgz",
+            "integrity": "sha512-W8JprYztwdFTtNLTa/aj2PGh8CJNBaMKrTtgOYlo8OvJrRn3XELRTeZoLyob5C49qW9aFiIYIIqm8zWysRFu8g=="
         },
         "immer": {
             "version": "9.0.18",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "dependencies": {
         "camel-case": "^4.1.2",
         "fp-ts": "^2.9.5",
-        "imgix-url-params": "^11.11.2",
+        "imgix-url-params": "^11.15.0",
         "md5": "^2.3.0",
         "node-fetch": "^2.6.1",
         "param-case": "^3.0.4"

--- a/src/createImgixUrlParamsInputType.ts
+++ b/src/createImgixUrlParamsInputType.ts
@@ -45,6 +45,9 @@ export const createImgixUrlParamsInputType = (
                     new Set(expects.map((expect) => expect.type)),
                 );
 
+                // @ts-expect-error TODO: remove this after short_description is marked as required in imgix-url-params
+                const shortDescription = spec.short_description || spec.display_name;
+
                 // TODO: Clean up this mess.
                 const type = expectsTypes.every(
                     (type) => type === 'integer' || type === 'unit_scalar',
@@ -64,9 +67,9 @@ export const createImgixUrlParamsInputType = (
                 fields[name] = {
                     type,
                     description:
-                        spec.short_description +
+                        shortDescription +
                         // Ensure the description ends with a period.
-                        (spec.short_description.slice(-1) === '.' ? '' : '.')
+                        (shortDescription.slice(-1) === '.' ? '' : '.')
                 };
 
                 const field = fields[


### PR DESCRIPTION
- this fix is cherry-picked from @imgix/gatsby, a module that replaced this package (https://github.com/imgix/gatsby/pull/271, d1a95e063d23334c3b77315532140dd1b4183e8e)